### PR TITLE
Added the predict end points and testing functionality 

### DIFF
--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -16,7 +16,7 @@ def configure_routes(app):
         return "try the predict route it is great!"
 
 
-    @app.route('/predictor')
+    @app.route('/predict')
     def predict():
         #use entries from the query string here but could also use json
         #useful data: school, traveltime, studytime, schoolsup, famsup, paid, 

--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -16,16 +16,42 @@ def configure_routes(app):
         return "try the predict route it is great!"
 
 
-    @app.route('/predict')
+    @app.route('/predictor')
     def predict():
         #use entries from the query string here but could also use json
-        age = request.args.get('age')
+        #useful data: school, traveltime, studytime, schoolsup, famsup, paid, 
+        #             activities, higher, internet, freetime, Dalc, Walc,
+        #             absences
+        # age = request.args.get('age')
+        # health = request.args.get('health')
+        school = request.args.get('school')
+        traveltime = request.args.get('travaltime')
+        studytime = request.args.get('studytime')
+        schoolsup = request.args.get('schoolsup')
+        famsup = request.args.get('famsup')
+        paid = request.args.get('paid')
+        activities = request.args.get('activities')
+        higher = request.args.get('higher')
+        internet = request.args.get('internet')
+        freetime = request.args.get('freetime')
+        dalc = request.args.get('Dalc')
+        walc = request.args.get('Walc')
         absences = request.args.get('absences')
-        health = request.args.get('health')
-        data = [[age], [health], [absences]]
+        data = [[school], [traveltime], [studytime], [schoolsup], [famsup], 
+                [paid], [activities], [higher], [internet], [freetime],
+                [dalc], [walc], [absences]]
         query_df = pd.DataFrame({
-            'age': pd.Series(age),
-            'health': pd.Series(health),
+            'school': pd.Series(school),
+            'traveltime': pd.Series(traveltime),
+            'studytime': pd.Series(studytime),
+            'schoolsup': pd.Series(famsup),
+            'paid': pd.Series(paid),
+            'activities': pd.Series(activities),
+            'higher': pd.Series(higher),
+            'internet': pd.Series(internet),
+            'freetime': pd.Series(freetime),
+            'dalc': pd.Series(dalc),
+            'walc': pd.Series(walc),
             'absences': pd.Series(absences)
         })
         query = pd.get_dummies(query_df)

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -21,7 +21,7 @@ def test_predict_route():
     url = '/predict'
  
     response = client.get(url)
-    correctJson = 
+    correctJson = [
     {"school": "GP", "traveltime": 1, "studytime": 2, "schoolsup": "no", "famsup": "no", "paid": "yes", 
     "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 4, "absences": 12},
     {"school": "MS", "traveltime": 3, "studytime": 1, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
@@ -37,21 +37,21 @@ def test_predict_route():
     {"school": "GP", "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
     "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
     {"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
-    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
-    
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}
+    ]
 
     # invalid studytime 
-    badStudy ={"school": "MS", "traveltime": 3, "studytime": -8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
-    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}
+    badStudy = [{"school": "MS", "traveltime": 3, "studytime": -8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
     #invalid internet 
-    badInternet = {"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
-    "activities": "yes", "higher": "yes", "internet": "YES", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}
+    badInternet = [{"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "YES", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
     #invalid schoolsup
-    badSchoolsUp = {"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "pl", "famsup": "yes", "paid": "yes", 
-    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}
+    badSchoolsUp = [{"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "pl", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
     #invalid walc
-    badWalc = {"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
-    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}
+    badWalc = [{"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}]
    
     assert response.status_code == 200
     assert requests.post(url, data=correctJson) == {"prediction": [12, 9, 5, 18, 19, 3, 5, 7]}

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -55,8 +55,8 @@ def test_predict_route():
    
     
     assert response.status_code == 200
-    assert response.get_data(currentJson) = {"prediction": [12, 9, 5, 18, 19, 3, 5, 7]}
-    assert response.get_data(badStudy) = {"prediction": [0]}
-    assert response.get_data(badInternet) = {"prediction": [0]}
-    assert response.get_data(badSchoolsUp) = {"prediction": [0]}
-    assert response.get_data(badWalc) = {"prediction": [0]}
+    assert response.get_data(currentJson) == {"prediction": [12, 9, 5, 18, 19, 3, 5, 7]}
+    assert response.get_data(badStudy) == {"prediction": [0]}
+    assert response.get_data(badInternet) == {"prediction": [0]}
+    assert response.get_data(badSchoolsUp) == {"prediction": [0]}
+    assert response.get_data(badWalc) == {"prediction": [0]}

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -13,3 +13,14 @@ def test_base_route():
 
     assert response.status_code == 200
     assert response.get_data() == b'try the predict route it is great!'
+
+def test_predict_route():
+    app = Flask(__name__)
+    configure_routes(app)
+    client = app.test_client()
+    url = '/predict'
+ 
+    response = client.get(url)
+ 
+    assert response.status_code == 200
+    assert response.get_data()

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -51,7 +51,7 @@ def test_predict_route():
     "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
     #invalid walc
     badWalc = [{"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
-    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}]
    
     
     assert response.status_code == 200

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -21,6 +21,42 @@ def test_predict_route():
     url = '/predict'
  
     response = client.get(url)
- 
+    correctJson = [
+    {"school": "GP", "traveltime": 1, "studytime": 2, "schoolsup": "no", "famsup": "no", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 4, "absences": 12},
+    {"school": "MS", "traveltime": 3, "studytime": 1, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93},
+    {"school": "MS", "traveltime": 3, "studytime": 4, "schoolsup": "no", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0},
+    {"school": "MS", "traveltime": 3, "studytime": 0, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
+    {"school": "GP", "traveltime": 0, "studytime": 0, "schoolsup": "no", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
+    {"school": "GP", "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
+    {"school": "GP", "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
+    {"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
+    ]
+
+    # invalid studytime 
+    badStudy =[{"school": "MS", "traveltime": 3, "studytime": -8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
+    #invalid internet 
+    badInternet = [{"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "YES", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
+    #invalid schoolsup
+    badSchoolsUp = [{"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "pl", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
+    #invalid walc
+    badWalc = [{"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}
+   
+    
     assert response.status_code == 200
-    assert response.get_data()
+    assert response.get_data(currentJson) = {"prediction": [12, 9, 5, 18, 19, 3, 5, 7]}
+    assert response.get_data(badStudy) = {"prediction": [0]}
+    assert response.get_data(badInternet) = {"prediction": [0]}
+    assert response.get_data(badSchoolsUp) = {"prediction": [0]}
+    assert response.get_data(badWalc) = {"prediction": [0]}

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -21,7 +21,7 @@ def test_predict_route():
     url = '/predict'
  
     response = client.get(url)
-    correctJson = [
+    correctJson = 
     {"school": "GP", "traveltime": 1, "studytime": 2, "schoolsup": "no", "famsup": "no", "paid": "yes", 
     "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 4, "absences": 12},
     {"school": "MS", "traveltime": 3, "studytime": 1, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
@@ -38,25 +38,24 @@ def test_predict_route():
     "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
     {"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
     "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": 4, "absences": 0}, 
-    ]
+    
 
     # invalid studytime 
-    badStudy =[{"school": "MS", "traveltime": 3, "studytime": -8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
-    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
+    badStudy ={"school": "MS", "traveltime": 3, "studytime": -8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}
     #invalid internet 
-    badInternet = [{"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
-    "activities": "yes", "higher": "yes", "internet": "YES", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
+    badInternet = {"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "yes", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "YES", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}
     #invalid schoolsup
-    badSchoolsUp = [{"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "pl", "famsup": "yes", "paid": "yes", 
-    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}]
+    badSchoolsUp = {"school": "MS", "traveltime": 3, "studytime": 8, "schoolsup": "pl", "famsup": "yes", "paid": "yes", 
+    "activities": "yes", "higher": "yes", "internet": "yes", "freetime": 3, "dalc": 3, "walc": 5, "absences": 93}
     #invalid walc
-    badWalc = [{"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
-    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}]
+    badWalc = {"school": 12, "traveltime": 0, "studytime": 4, "schoolsup": "yes", "famsup": "no", "paid": "yes", 
+    "activities": "no", "higher": "no", "internet": "no", "freetime": 3, "dalc": 3, "walc": "yo", "absences": 0}
    
-    
     assert response.status_code == 200
-    assert response.get_data(currentJson) == {"prediction": [12, 9, 5, 18, 19, 3, 5, 7]}
-    assert response.get_data(badStudy) == {"prediction": [0]}
-    assert response.get_data(badInternet) == {"prediction": [0]}
-    assert response.get_data(badSchoolsUp) == {"prediction": [0]}
-    assert response.get_data(badWalc) == {"prediction": [0]}
+    assert requests.post(url, data=correctJson) == {"prediction": [12, 9, 5, 18, 19, 3, 5, 7]}
+    assert requests.post(url, data=badStudy) == {"prediction": [0]}
+    assert requests.post(url, data=badInternet) == {"prediction": [0]}
+    assert requests.post(url, data=badSchoolsUp) == {"prediction": [0]}
+    assert requests.post(url, data=badWalc) == {"prediction": [0]}


### PR DESCRIPTION
Include all parameters that we consider related to G3 score:

School (different school curriculum and standards may contribute to G3)
traveltime (explains low study time or lack of extracurriculars)
studytime (correlated)
failures (correlated)
schoolsup (correlated)
famsup (correlated)
paid (more exposure to course content)
activities (correlated w/ time and friends and general happiness)
higher (correlated)
internet (no internet makes communication and searching things up more difficult)
freetime (correlated, can compare how this goes up against studytime to see their dedication)
Dalc (correlated)
Walc (correlated)
absences (correlated)
Check data validity in terms of a) if it contains all required fields 2) if each field is of the correct type and range. Considered both expected behavior and edge cases.

Adjusted tests so that were in correct json format instead of multiple separate lists. 

[Note:] The tests will not pass since we have not implemented API endpoints yet. Data are in form of dummy data.